### PR TITLE
Added proper info/warning in Tx types within their specific versions 

### DIFF
--- a/docs/onchain/API/types/V1/Tx/PTxId.mdx
+++ b/docs/onchain/API/types/V1/Tx/PTxId.mdx
@@ -4,6 +4,10 @@ sidebar_position: 17
 
 # `PTxId`
 
+:::warning
+Modified in V3 version
+:::
+
 Type that represents the unique identifier of a transaction.
 
 Definition:

--- a/docs/onchain/API/types/V3/Tx/PTxOutRef.mdx
+++ b/docs/onchain/API/types/V3/Tx/PTxOutRef.mdx
@@ -5,7 +5,7 @@ sidebar_position: 20
 # `PTxOutRef`
 
 :::warning
-Modified in V3 version as PTxId is modified
+Modified from V1 version, as PTxId in V3 is updated.
 :::
 
 Type that represents a reference to a UTXO.


### PR DESCRIPTION
PTxId - modified entirely in V3

Hence, PTxOutRef in V3 is also modified, as it refers to the updated V3-PTxId ; and not the V1.